### PR TITLE
Split by comma, not by dot to support ip addresses

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func CreateFunctionNotifyFunction(bot *irc.Connection) http.HandlerFunc {
 
 			for _, alert := range alertList {
 				name := alert.Labels["instance"].(string)
-				name = strings.Split(name, ".")[0]
+				name = strings.Split(name, ",")[0]
 				value, ok := alert.Labels["value"].(string)
 				if ok {
 					instance = Instance{Name: name, Value: value}


### PR DESCRIPTION
Alertmanager segments by comma, not by dot, thus IP addresses are
malformed before this commit.